### PR TITLE
Markdown adjustments to read me and change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,4 +67,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Richard Purves
 
 
-
+[0.4.0]: https://github.com/Shufflepuck/cdef/compare/v2.3.0...v2.4.0
+[0.3.0]: https://github.com/Shufflepuck/cdef/compare/v0.2.1...v2.3.0
+[0.2.1]: https://github.com/Shufflepuck/cdef/compare/v0.2...v0.2.1

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+# cdef
 
 `cdef` is a handy command-line tool to mess with your default applications.
 
@@ -15,7 +16,7 @@ Download it from the [Releases page](https://github.com/ftiff/cdef/releases)
 
 Note: Please fork and Pull Request, or [create an issue](https://github.com/ftiff/cdef/issues)
 
-# What are UTI? (Uniform Type Identifiers)
+## What are UTI? (Uniform Type Identifiers)
 
 Uniform type identifiers (UTIs) provide a unified way to identify data handled within the system, such as documents, pasteboard data, and bundles. This chapter describes the concepts behind UTIs and shows how to specify them in your application bundles.
 
@@ -23,15 +24,17 @@ Have more information on [Apple's website](https://developer.apple.com/library/i
 
 
 
-# Examples
+## Examples
 
-###Get the default application to open PNG files:
+### Get the default application to open PNG files:
+
 ```
 $ cdef -readdefaultuti public.png
 public.png -> com.apple.Preview
 ```
 
-###Get all applications that *can* open PNG files:
+### Get all applications that *can* open PNG files:
+
 ```
 $ cdef -readalluti public.png
 public.png -> com.pixelmatorteam.pixelmator
@@ -41,25 +44,29 @@ public.png -> com.apple.ColorSyncUtility
 public.png -> com.apple.Preview
 ```
 
-###Get which application will open `http://` URLs:
+### Get which application will open `http://` URLs:
+
 ```
 $ cdef -readdefaulturl http
 http -> com.apple.Safari
 ```
 
-###Change your default browser to Chrome:
+### Change your default browser to Chrome:
+
 ```
 $ cdef -writedefaulturl http com.google.chrome
 ```
 
-###Get supported URL types for Apple Mail:
+### Get supported URL types for Apple Mail:
+
 ```
 $ cdef -readURLTypes /Applications/Mail.app/
 mailto
 message
 ```
 
-###Get supported Document types for Apple Mail:
+### Get supported Document types for Apple Mail:
+
 ```
 √        -> Application is default for this type
 x        -> Application supports but is not default for this type
@@ -81,11 +88,12 @@ x com.apple.mail.emlx.part (None)
 
 Note: This will prompt a dialog to ask the user to confirm the change to Chrome.
 
-I use it in my deployments as a Casper policy that executes `/usr/bin/sudo -u#501 /usr/local/bin/cdef -writedefaulturl http com.google.chrome`
+I use it in my deployments as a Jamf policy that executes `/usr/bin/sudo -u#501 /usr/local/bin/cdef -writedefaulturl http com.google.chrome`
 
 See the list of UTIs here: https://developer.apple.com/library/ios/documentation/Miscellaneous/Reference/UTIRef/Articles/System-DeclaredUniformTypeIdentifiers.html#//apple_ref/doc/uid/TP40009259-SW1
 
-# Developers
+## Developers
+
 You're more than welcome to contribute to the code!
 
 Everything needed to create a package is under cdef-Package/. Just run cdef-Package/build_pkg.sh !


### PR DESCRIPTION
The read me headings weren't displaying correctly on GitHub. This PR fixes that, and adds diff links (per "keep a change log" example) to the change log.